### PR TITLE
Support eager loading translations

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -90,9 +90,15 @@ trait Translatable
             return $this->cache[$locale];
         }
 
-        $translation = $this->translations()
-            ->where('locale', $locale)
-            ->first();
+        if ($this->relationLoaded('translations')) {
+            $translation = $this->translations
+                ->where('locale', $locale)
+                ->first();
+        } else {
+            $translation = $this->translations()
+                ->where('locale', $locale)
+                ->first();
+        }
 
         if ($translation) {
             $this->cache[$locale] = $translation;

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Vinkla\Translator;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\App;
@@ -31,6 +32,23 @@ trait Translatable
      * @var array
      */
     protected $cache = [];
+
+    /**
+     * Query scope for eager-loading the translations for current (or a given) locale.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param string $locale
+     *
+     * @return void
+     */
+    public static function scopeWithTranslations(Builder $builder, string $locale = null)
+    {
+        $locale = $locale ?: (new static)->getLocale();
+
+        $builder->with(['translations' => function (HasMany $query) use ($locale) {
+            $query->where('locale', $locale);
+        }]);
+    }
 
     /**
      * Get a translation.

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -211,6 +211,30 @@ class TranslatorTest extends AbstractTestCase
         }));
     }
 
+    public function testWithTranslationsScopeWithNoParameter()
+    {
+        $article = Article::take(1)->withTranslations()->get()->first();
+
+        $this->assertTrue($article->relationLoaded('translations'));
+
+        $this->assertSame(0, $this->getQueryCount(function () use ($article) {
+            $this->assertSame(1, $article->translations->count());
+            $this->assertSame('Använd kraften Harry', $article->title);
+        }));
+    }
+
+    public function testWithTranslationsScopeWithParameter()
+    {
+        $article = Article::take(1)->withTranslations('en')->get()->first();
+
+        $this->assertTrue($article->relationLoaded('translations'));
+
+        $this->assertSame(0, $this->getQueryCount(function () use ($article) {
+            $this->assertSame(1, $article->translations->count());
+            $this->assertSame('Use the force Harry', $article->title);
+        }));
+    }
+
     protected function getProtectedMethod($instance, $method, $parameters = null)
     {
         $rc = new ReflectionClass($instance);


### PR DESCRIPTION
Revisiting PR #34, whose feature must have been left behind in a version change.

Additionally to caching the translations, this PR loads the translation as an Eloquent relation. Also, I added a query scope for easily eager loading translations for a single locale.
