### PR TITLE
Config facade

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -16,7 +16,6 @@ namespace Vinkla\Translator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -255,7 +254,7 @@ trait Translatable
      */
     protected function setLocale(string $locale)
     {
-        App::setLocale($locale);
+        Config::set('app.locale', $locale);
     }
 
     /**
@@ -265,7 +264,7 @@ trait Translatable
      */
     protected function getLocale(): string
     {
-        return App::getLocale();
+        return Config::get('app.locale');
     }
 
     /**

--- a/tests/database/migrations/2017_01_01_000001_create_articles_table.php
+++ b/tests/database/migrations/2017_01_01_000001_create_articles_table.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * This is the articles table seeder class.
+ * This is the articles table creation migration class.
  *
  * @author Vincent Klaiber <hello@vinkla.com>
  */

--- a/tests/database/migrations/2017_01_01_000001_create_articles_table.php
+++ b/tests/database/migrations/2017_01_01_000001_create_articles_table.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * This is the articles table creation migration class.
+ * This is the create articles table migration class.
  *
  * @author Vincent Klaiber <hello@vinkla.com>
  */

--- a/tests/database/migrations/2017_01_01_000002_create_article_translations_table.php
+++ b/tests/database/migrations/2017_01_01_000002_create_article_translations_table.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * This is the article translations table creation migration class.
+ * This is the create article translations table migration class.
  *
  * @author Vincent Klaiber <hello@vinkla.com>
  */

--- a/tests/database/migrations/2017_01_01_000002_create_article_translations_table.php
+++ b/tests/database/migrations/2017_01_01_000002_create_article_translations_table.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * This is the article translations table seeder class.
+ * This is the article translations table creation migration class.
  *
  * @author Vincent Klaiber <hello@vinkla.com>
  */


### PR DESCRIPTION
Preferring `Config` over `App` facades for getting/setting the app locale allows use in Lumen applications too (`Laravel\Lumen\Application` doesn't implement `getLocale` / `setLocale` methods).