### PR TITLE
Feature/81 use events for saving

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -32,14 +32,15 @@ trait Translatable
      */
     protected $translationCache = [];
 
+    /**
+     * Boot the translatable trait.
+     *
+     * @return void
+     */
     public static function bootTranslatable(): void
     {
-        static::created(function (Model $model) {
-            $model->saveTranslations();
-        });
-
-        static::updated(function (Model $model) {
-            $model->saveTranslations();
+        static::saved(function (Model $model) {
+            $model->translations()->saveMany($model->translationCache);
         });
     }
 
@@ -234,11 +235,6 @@ trait Translatable
         }
 
         return false;
-    }
-
-    protected function saveTranslations(): void
-    {
-        $this->translations()->saveMany($this->translationCache);
     }
 
     /**

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -39,7 +39,11 @@ trait Translatable
      */
     public static function bootTranslatable(): void
     {
-        static::saved(function (Model $model) {
+        static::created(function (Model $model) {
+            $model->translations()->saveMany($model->translationCache);
+        });
+
+        static::updating(function (Model $model) {
             $model->translations()->saveMany($model->translationCache);
         });
     }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -34,11 +34,11 @@ trait Translatable
 
     public static function bootTranslatable(): void
     {
-        static::updated(function (Model $model) {
+        static::created(function (Model $model) {
             $model->saveTranslations();
         });
 
-        static::created(function (Model $model) {
+        static::updated(function (Model $model) {
             $model->saveTranslations();
         });
     }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -32,6 +32,17 @@ trait Translatable
      */
     protected $translationCache = [];
 
+    public static function bootTranslatable(): void
+    {
+        static::updated(function (Model $model) {
+            $model->saveTranslations();
+        });
+
+        static::created(function (Model $model) {
+            $model->saveTranslations();
+        });
+    }
+
     /**
      * Get a translation.
      *
@@ -225,18 +236,9 @@ trait Translatable
         return false;
     }
 
-    /**
-     * Finish processing on a successful save operation.
-     *
-     * @param array $options
-     *
-     * @return void
-     */
-    protected function finishSave(array $options): void
+    protected function saveTranslations(): void
     {
         $this->translations()->saveMany($this->translationCache);
-
-        parent::finishSave($options);
     }
 
     /**

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -152,11 +152,11 @@ class TranslatorTest extends AbstractTestCase
 
     public function testUpdate()
     {
+        $article = Article::find(1);
+
         App::setLocale('en');
 
-        $article = Article::find(1);
-        $article->title = 'Whoa. This is heavy.';
-        $article->save();
+        $article->update(['title' => 'Whoa. This is heavy.']);
 
         $this->assertDatabaseHas('article_translations', ['title' => 'Whoa. This is heavy.', 'article_id' => $article->id, 'locale' => 'en']);
 

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -152,8 +152,6 @@ class TranslatorTest extends AbstractTestCase
 
     public function testUpdate()
     {
-        $article = Article::find(1);
-
         App::setLocale('en');
 
         $article = Article::find(1);

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -156,7 +156,9 @@ class TranslatorTest extends AbstractTestCase
 
         App::setLocale('en');
 
-        $article->update(['title' => 'Whoa. This is heavy.']);
+        $article = Article::find(1);
+        $article->title = 'Whoa. This is heavy.';
+        $article->save();
 
         $this->assertDatabaseHas('article_translations', ['title' => 'Whoa. This is heavy.', 'article_id' => $article->id, 'locale' => 'en']);
 


### PR DESCRIPTION
Related to #81.

I made a proposal here on how to avoid overriding `finishSave`, and instead listen for `updated` and `created` and save translations after that, leaving the core model code untouched.

I am having problems though, with getting `TranslatorTest::testUpdate` to pass, something I was unable to figure out. Perhaps you can lend a hand here @vinkla ?